### PR TITLE
BUGFIX: Support Version without timestamp

### DIFF
--- a/Classes/Command/MarketPlaceCommandController.php
+++ b/Classes/Command/MarketPlaceCommandController.php
@@ -91,6 +91,9 @@ class MarketPlaceCommandController extends CommandController
                 $this->cleanupPackages($storage);
                 $this->cleanupVendors($storage);
                 $this->logger->log(sprintf('action=%s duration=%f', LogAction::FULL_SYNC_FINISHED, $elapsedTime()), LOG_INFO);
+
+				$this->outputLine();
+				$this->outputLine(sprintf('%d package(s) imported with success', $this->importer->getProcessedPackagesCount()));
             } else {
                 $packageKey = $package;
                 $this->logger->log(sprintf('action=%s package=%s', LogAction::SINGLE_PACKAGE_SYNC_STARTED, $package), LOG_INFO);
@@ -104,10 +107,14 @@ class MarketPlaceCommandController extends CommandController
                     $this->logger->logException($exception);
                     $hasError = true;
                 }
-            }
 
-            $this->outputLine();
-            $this->outputLine(sprintf('%d package(s) imported with success', $this->importer->getProcessedPackagesCount()));
+				$this->outputLine();
+                if ($hasError) {
+					$this->outputLine(sprintf('Package "%s" import failed', $packageKey));
+				} else {
+					$this->outputLine(sprintf('Package "%s" imported with success', $packageKey));
+				}
+            }
 
             if ($hasError) {
                 $this->outputLine();

--- a/Classes/Property/TypeConverter/PackageConverter.php
+++ b/Classes/Property/TypeConverter/PackageConverter.php
@@ -132,7 +132,11 @@ class PackageConverter extends AbstractTypeConverter
         $lastActivities = [];
         /** @var Package\Version $version */
         foreach ($package->getVersions() as $version) {
-            $time = \DateTime::createFromFormat(\DateTime::ISO8601, $version->getTime());
+			$time = $version->getTime();
+			if ($time === null) {
+				continue;
+			}
+            $time = \DateTime::createFromFormat(\DateTime::ISO8601, $time);
             $lastActivities[$time->getTimestamp()] = $time;
         }
         krsort($lastActivities);

--- a/Classes/Service/PackageVersion.php
+++ b/Classes/Service/PackageVersion.php
@@ -56,6 +56,9 @@ class PackageVersion
             $aTime = $a->getProperty('time');
             /** @var \DateTime $bTime */
             $bTime = $b->getProperty('time');
+            if ($aTime === false || $bTime === false) {
+            		return -1;
+			}
             return $bTime->getTimestamp() - $aTime->getTimestamp();
         });
         $stableVersions = array_filter($versions, function(NodeInterface $version) {


### PR DESCRIPTION
This fix a bug when importing version like 2.2.x-dev where composer return 
no time value.