### PR TITLE
TASK: Remove second call to handleAbandonedPackageOrVersion

### DIFF
--- a/Classes/Property/TypeConverter/PackageConverter.php
+++ b/Classes/Property/TypeConverter/PackageConverter.php
@@ -484,8 +484,6 @@ class PackageConverter extends AbstractTypeConverter
                     'shasum' => $version->getDist()->getShasum(),
                 ]);
             }
-
-            $this->handleAbandonedPackageOrVersion($package, $node);
         }
     }
 


### PR DESCRIPTION
The method is also called from `convertFrom` and thus not needed here