### PR TITLE
Add Carbon Package Namespace to typeMapping

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -10,6 +10,7 @@ Neos:
       neos-framework: neos-framework
       neos-build: neos-build
       neos-boilerplate: neos-boilerplate
+      neos-carbon: neos-carbon
     vendorMapping:
       neos: true
       flowpack: true


### PR DESCRIPTION
The packages from https://github.com/CarbonPackages have an own namespace to collect these little helpers into one folder. To make sure these get also listed on neos.io, I add the typeMapping `neos-carbon`